### PR TITLE
README Fix links to the samples directory and a typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ var channel = sound.Play();
 channel.Looping = true;
 ```
 
-`_nativeLibrary` is an instance of `INativeFmodLibrary` that you have to create separately in your platform-specific projects. [Samples project](/FmodForFoxes.Samples) already has this set up.
+`_nativeLibrary` is an instance of `INativeFmodLibrary` that you have to create separately in your platform-specific projects. [Samples project](/Samples) already has this set up.
 
 And lastly, do note that `FmodManager` has to be properly updated and unloaded. Your main gameloop class has to have this added:
 
@@ -169,7 +169,7 @@ protected override void Update(GameTime gameTime)
 
 4. Compile and hope that you (and me) did everything right.
 
-You can also check out the incluided [Samples project](/FmodForFoxes.Samples). 
+You can also check out the included [Samples project](/Samples). 
 
 ## But what about other platforms?
 


### PR DESCRIPTION
Two of the links to the samples projects are broken in the readme and there was a typo. This PR amends the issue!

PS thanks for this repo!